### PR TITLE
修复 不锁定lombok版本导致的BUG

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,7 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <scope>provided</scope>
+            <version>1.18.8</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
修复 不锁定lombok版本导致的执行 mvn clean package -DskipTests 报下面的错误

”“”
Lombok annotation handler class lombok.javac.handlers.HandleBuilder failed on /Users/lihong/learn/java/staffjoy/company-api/src/main/java/xyz/staffjoy/company/dto/TimeZoneList.java: java.lang.IllegalStateException: Lombok TreeMaker frontend issue: no match when looking for method: com.sun.tools.javac.tree.JCTree$JCCase com.sun.tools.javac.tree.TreeMaker.Case(com.sun.tools.javac.tree.JCTree$JCExpression, com.sun.tools.javac.util.List)

“”“